### PR TITLE
Add styling possibilities for the output

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,11 @@
             <div id='table-wrapper'>
             </div>
             <br>
+            <p>Style: <select id="style" name="style" onchange="genPTT()">
+              <option value="simple">Single border</option>
+              <option value="double">Double border</option>
+              <option value="ascii">ASCII characters</option>
+            </select></p>
             <pre id="ptt-wrapper"></pre>
             <hr>
 

--- a/js/main.js
+++ b/js/main.js
@@ -35,22 +35,37 @@
     }
 
     function genPTT(){
+        var style = {
+            horizontal: '─',
+            vertical: '│',
+            top_left: '┌',
+            top_center: '┬',
+            top_right: '┐',
+            middle_left: '├',
+            middle_center: '┼',
+            middle_right: '┤',
+            bottom_left: '└',
+            bottom_center: '┴',
+            bottom_right: '┘'
+        }
+
         var arr = extractData();
         var widths = getWidths(arr);
         var str = "";
         var i, j, k, m, entry, row, pseudoRows, plen;
 
         // top
-        str += '┌';
+        str += style['top_left'];
         for (i = 0; i < widths.length; i++) {
             for (j = 0; j < widths[i]; j++) {
-                str += '─';
+                str += style['horizontal'];
             }
             if (i < widths.length-1) {
-                str += '┬';
+                str += style['top_center'];
             }
         }
-        str += '┐\n';
+        str += style['top_right'];
+        str += '\n';
 
         // rows
         for (k = 0; k < arr.length; k++) {
@@ -72,7 +87,7 @@
             }
 
             for (m = 0; m < pseudoRows.length; m++) {
-                str += '│';
+                str += style['vertical'];
                 for (i = 0; i < widths.length; i++) {
                     entry = pseudoRows[m][i] || '';
                     str += entry;
@@ -80,38 +95,41 @@
                         str += ' ';
                     }
                     if (i < widths.length-1) {
-                        str += '│';
+                        str += style['vertical'];
                     }
                 }
-                str += '│\n';
+                str += style['vertical'];
+                str += '\n';
             }
 
 
             if (k < arr.length-1) {
-                str += '├';
+                str += style['middle_left'];
                 for (i = 0; i < widths.length; i++) {
                     for (j = 0; j < widths[i]; j++) {
-                        str += '─';
+                        str += style['horizontal'];
                     }
                     if (i < widths.length-1) {
-                        str += '┼';
+                        str += style['middle_center'];
                     }
                 }
-                str += '┤\n';
+                str += style['middle_right'];
+                str += '\n';
             }
         }
 
         // bottom
-        str += '└';
+        str += style['bottom_left'];
         for (i = 0; i < widths.length; i++) {
             for (j = 0; j < widths[i]; j++) {
-                str += '─';
+                str += style['horizontal'];
             }
             if (i < widths.length-1) {
-                str += '┴';
+                str += style['bottom_center'];
             }
         }
-        str += '┘\n';
+        str += style['bottom_right'];
+        str += '\n';
         $('#ptt-wrapper').text(str);
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -9,33 +9,42 @@
         });
     }
 
-    function extractData(){
-        return $('#table-wrapper').handsontable('getData');
-    }
+    createTable();
+})();
 
-    function getWidths(arr){
-        var widths = [];
-        var i, j, k, w, item, lines;
-
-        for(i = 0; i < arr.length; i++) {
-            for (j = 0; j < arr[i].length; j++) {
-                w = widths[j] || 0;
-                item = arr[i][j];
-                if (! item) continue;
-                lines = item.split('\n');
-                for (k = 0; k < lines.length; k++) {
-                    if (lines[k].length > w) {
-                        w = lines[k].length;
-                    }
-                }
-                widths[j] = w;
-            }
+function genPTT(){
+    var style;
+    var styleOption = document.getElementById('style').value;
+    if('double' == styleOption) {
+        style = {
+            horizontal: '═',
+            vertical: '║',
+            top_left: '╔',
+            top_center: '╦',
+            top_right: '╗',
+            middle_left: '╠',
+            middle_center: '╬',
+            middle_right: '╣',
+            bottom_left: '╚',
+            bottom_center: '╩',
+            bottom_right: '╝'
         }
-        return widths;
-    }
-
-    function genPTT(){
-        var style = {
+    } else if('ascii' == styleOption) {
+        style = {
+            horizontal: '-',
+            vertical: '|',
+            top_left: '+',
+            top_center: '+',
+            top_right: '+',
+            middle_left: '+',
+            middle_center: '+',
+            middle_right: '+',
+            bottom_left: '+',
+            bottom_center: '+',
+            bottom_right: '+'
+        }
+    } else {
+        style = {
             horizontal: '─',
             vertical: '│',
             top_left: '┌',
@@ -48,90 +57,113 @@
             bottom_center: '┴',
             bottom_right: '┘'
         }
-
-        var arr = extractData();
-        var widths = getWidths(arr);
-        var str = "";
-        var i, j, k, m, entry, row, pseudoRows, plen;
-
-        // top
-        str += style['top_left'];
-        for (i = 0; i < widths.length; i++) {
-            for (j = 0; j < widths[i]; j++) {
-                str += style['horizontal'];
-            }
-            if (i < widths.length-1) {
-                str += style['top_center'];
-            }
-        }
-        str += style['top_right'];
-        str += '\n';
-
-        // rows
-        for (k = 0; k < arr.length; k++) {
-
-            row = arr[k];
-            pseudoRows = [];
-
-            for (i = 0; i < widths.length; i++) {
-                entry = arr[k][i];
-                if (! entry) continue;
-                entry = entry.split('\n');
-                plen = pseudoRows.length;
-                for (j = 0; j < entry.length - plen; j++) {
-                    pseudoRows.push([]);
-                }
-                for (j = 0; j < entry.length; j++) {
-                    pseudoRows[j][i] = entry[j];
-                }
-            }
-
-            for (m = 0; m < pseudoRows.length; m++) {
-                str += style['vertical'];
-                for (i = 0; i < widths.length; i++) {
-                    entry = pseudoRows[m][i] || '';
-                    str += entry;
-                    for (j = entry.length; j < widths[i]; j++) {
-                        str += ' ';
-                    }
-                    if (i < widths.length-1) {
-                        str += style['vertical'];
-                    }
-                }
-                str += style['vertical'];
-                str += '\n';
-            }
-
-
-            if (k < arr.length-1) {
-                str += style['middle_left'];
-                for (i = 0; i < widths.length; i++) {
-                    for (j = 0; j < widths[i]; j++) {
-                        str += style['horizontal'];
-                    }
-                    if (i < widths.length-1) {
-                        str += style['middle_center'];
-                    }
-                }
-                str += style['middle_right'];
-                str += '\n';
-            }
-        }
-
-        // bottom
-        str += style['bottom_left'];
-        for (i = 0; i < widths.length; i++) {
-            for (j = 0; j < widths[i]; j++) {
-                str += style['horizontal'];
-            }
-            if (i < widths.length-1) {
-                str += style['bottom_center'];
-            }
-        }
-        str += style['bottom_right'];
-        str += '\n';
-        $('#ptt-wrapper').text(str);
     }
 
-    createTable();
-})();
+    var arr = extractData();
+    var widths = getWidths(arr);
+    var str = "";
+    var i, j, k, m, entry, row, pseudoRows, plen;
+
+    // top
+    str += style['top_left'];
+    for (i = 0; i < widths.length; i++) {
+        for (j = 0; j < widths[i]; j++) {
+            str += style['horizontal'];
+        }
+        if (i < widths.length-1) {
+            str += style['top_center'];
+        }
+    }
+    str += style['top_right'];
+    str += '\n';
+
+    // rows
+    for (k = 0; k < arr.length; k++) {
+
+        row = arr[k];
+        pseudoRows = [];
+
+        for (i = 0; i < widths.length; i++) {
+            entry = arr[k][i];
+            if (! entry) continue;
+            entry = entry.split('\n');
+            plen = pseudoRows.length;
+            for (j = 0; j < entry.length - plen; j++) {
+                pseudoRows.push([]);
+            }
+            for (j = 0; j < entry.length; j++) {
+                pseudoRows[j][i] = entry[j];
+            }
+        }
+
+        for (m = 0; m < pseudoRows.length; m++) {
+            str += style['vertical'];
+            for (i = 0; i < widths.length; i++) {
+                entry = pseudoRows[m][i] || '';
+                str += entry;
+                for (j = entry.length; j < widths[i]; j++) {
+                    str += ' ';
+                }
+                if (i < widths.length-1) {
+                    str += style['vertical'];
+                }
+            }
+            str += style['vertical'];
+            str += '\n';
+        }
+
+
+        if (k < arr.length-1) {
+            str += style['middle_left'];
+            for (i = 0; i < widths.length; i++) {
+                for (j = 0; j < widths[i]; j++) {
+                    str += style['horizontal'];
+                }
+                if (i < widths.length-1) {
+                    str += style['middle_center'];
+                }
+            }
+            str += style['middle_right'];
+            str += '\n';
+        }
+    }
+
+    // bottom
+    str += style['bottom_left'];
+    for (i = 0; i < widths.length; i++) {
+        for (j = 0; j < widths[i]; j++) {
+            str += style['horizontal'];
+        }
+        if (i < widths.length-1) {
+            str += style['bottom_center'];
+        }
+    }
+    str += style['bottom_right'];
+    str += '\n';
+    $('#ptt-wrapper').text(str);
+}
+
+function extractData(){
+    return $('#table-wrapper').handsontable('getData');
+}
+
+function getWidths(arr){
+    var widths = [];
+    var i, j, k, w, item, lines;
+
+    for(i = 0; i < arr.length; i++) {
+        for (j = 0; j < arr[i].length; j++) {
+            w = widths[j] || 0;
+            item = arr[i][j];
+            if (! item) continue;
+            lines = item.split('\n');
+            for (k = 0; k < lines.length; k++) {
+                if (lines[k].length > w) {
+                    w = lines[k].length;
+                }
+            }
+            widths[j] = w;
+        }
+    }
+    return widths;
+}


### PR DESCRIPTION
This pull request introduces an associative array to add the possibility to exchange the style.

For the moment I did not extend the UI but I would like to have some additional configuration options between the `#table-wrapper` and the `#ptt-wrapper`. In this case I think of a combo box providing those options:

* Single border
* Double border
* ASCII characters

__Single border__ correspond to the existing implementation.

__Double border__ correspond to this array:

        var style = {
            horizontal: '═',
            vertical: '║',
            top_left: '╔',
            top_center: '╦',
            top_right: '╗',
            middle_left: '╠',
            middle_center: '╬',
            middle_right: '╣',
            bottom_left: '╚',
            bottom_center: '╩',
            bottom_right: '╝'
        }

__ASCII characters__ correspond to this array:

        var style = {
            horizontal: '-',
            vertical: '|',
            top_left: '+',
            top_center: '+',
            top_right: '+',
            middle_left: '+',
            middle_center: '+',
            middle_right: '+',
            bottom_left: '+',
            bottom_center: '+',
            bottom_right: '+'
        }

